### PR TITLE
add file size validation and logging for vertex inline files

### DIFF
--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -22,6 +22,7 @@ const MAX_EXTRACTED_TEXT_CHARS = 120_000;
 const MAX_PROMPT_CONTEXT_CHARS = 90_000;
 const MAX_VERTEX_INLINE_FILE_BYTES = 7 * 1024 * 1024;
 const MAX_VERTEX_INLINE_FILE_LABEL = "7 MiB";
+const PRE_DOWNLOAD_CONTENT_LENGTH_TOLERANCE_BYTES = 128 * 1024;
 
 const vertexProviderOptions = {
   google: {
@@ -334,12 +335,15 @@ const buildModelInputFromDocuments = async <TStorageId>(
 
       if (
         Number.isFinite(contentLength) &&
-        contentLength > MAX_VERTEX_INLINE_FILE_BYTES
+        contentLength >
+          MAX_VERTEX_INLINE_FILE_BYTES +
+            PRE_DOWNLOAD_CONTENT_LENGTH_TOLERANCE_BYTES
       ) {
-        trace?.log("warn", "model_input_document_too_large", {
+        trace?.log("warn", "model_input_document_declared_too_large", {
           fileName: document.fileName,
           declaredSizeBytes: contentLength,
           maxInlineBytes: MAX_VERTEX_INLINE_FILE_BYTES,
+          toleranceBytes: PRE_DOWNLOAD_CONTENT_LENGTH_TOLERANCE_BYTES,
         });
         throw buildInlineFileTooLargeError(document.fileName, contentLength);
       }


### PR DESCRIPTION
## Before:
<img width="997" height="687" alt="image" src="https://github.com/user-attachments/assets/081f377d-7ea1-4e3d-96e2-5d4e2aed6996" />
It sometimes worked, sometimes it didn't work (very unstable), the error is not giving much information



## Now:
<img width="890" height="654" alt="image" src="https://github.com/user-attachments/assets/8d86fa32-39cd-43af-8e60-4b1f53654eea" />
There is a hard limit at 7 MiB per file with a clear error, this means that sometimes even files that would've worked don't work but we have a clear behaviour