### PR TITLE
Prevent KPI card overflow in Lernanalyse layout

### DIFF
--- a/src/features/study/components/KpiCard.tsx
+++ b/src/features/study/components/KpiCard.tsx
@@ -5,11 +5,11 @@ type KpiCardProps = {
 
 export function KpiCard({ label, value }: KpiCardProps) {
   return (
-    <div className="border-cream-border bg-surface-white rounded-[1.5rem] border p-5 shadow-sm transition duration-300 hover:scale-[1.02] md:rounded-[2rem] md:p-8">
+    <div className="border-cream-border bg-surface-white min-w-0 rounded-[1.5rem] border p-5 shadow-sm transition duration-300 hover:scale-[1.02] md:rounded-[2rem] md:p-8">
       <p className="text-accent mb-2 text-[9px] font-bold tracking-[0.2em] uppercase md:text-[10px]">
         {label}
       </p>
-      <p className="text-ink text-lg font-black tracking-tight md:text-2xl">
+      <p className="text-ink max-w-full text-lg leading-tight font-black tracking-tight [overflow-wrap:anywhere] md:text-2xl">
         {value}
       </p>
     </div>


### PR DESCRIPTION
- add `min-w-0` to KPI card container to allow shrinking in tight layouts
- wrap long KPI values safely with `overflow-wrap:anywhere` and constrained width
<img width="1276" height="895" alt="image" src="https://github.com/user-attachments/assets/b8e338df-c551-4092-aa50-627630761372" />
