### PR TITLE
Preserve quiz state when continuing after feedback

### DIFF
--- a/src/features/study/hooks/useQuizFlow.ts
+++ b/src/features/study/hooks/useQuizFlow.ts
@@ -133,9 +133,6 @@ export function useQuizFlow({
 
   const continueAfterFeedback = useCallback(() => {
     setFeedback(null);
-    setAnswerInput("");
-    setQuizError(null);
-    setQuestionStartedAt(Date.now());
   }, []);
 
   return {


### PR DESCRIPTION
- Stop clearing answer input on feedback continuation
- Keep existing error and question start timestamp intact

Fix https://github.com/Smartnotes-Germany/smartnotes-mvp/pull/46#discussion_r2914164589