### PR TITLE
Clarify Vertex native processing coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The AI pipeline uses the Vercel AI SDK with Google Vertex AI.
 - Frontend: React 19, Vite, Tailwind CSS
 - Backend: Convex (database, file storage, server functions)
 - AI: `ai` + `@ai-sdk/google-vertex`
-- Document processing: Vertex file input (PDF/PPT/PPTX/DOC/DOCX/JPG/JPEG/PNG/WEBP) + `officeparser` fallback
+- Document processing: native Vertex file input for PDF/JPG/JPEG/PNG/WEBP, plus `officeparser` extraction for PPT/PPTX/DOC/DOCX and text-based formats
 
 ## Prerequisites
 

--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -503,7 +503,62 @@ const buildModelInputFromDocuments = async (
         fileName: document.fileName,
         extractedText: document.extractedText,
       });
+      continue;
     }
+
+    const textLoadStartedAt = Date.now();
+    trace?.log("info", "model_input_text_fallback_started", {
+      fileName: document.fileName,
+      fileType: document.fileType,
+      fileSizeBytes: document.fileSizeBytes,
+    });
+
+    const { fileUrl, source, status, grantErrorDetail } =
+      await createDocumentReadUrl(ctx, document.storageId, accessKey, trace);
+    if (!fileUrl) {
+      throw new Error(
+        `Datei konnte nicht gelesen werden: ${document.fileName}`,
+      );
+    }
+
+    trace?.log("info", "model_input_text_fallback_url_loaded", {
+      fileName: document.fileName,
+      source,
+      status,
+      grantErrorDetail,
+      elapsedMs: Date.now() - textLoadStartedAt,
+    });
+
+    const response = await fetch(fileUrl);
+    if (!response.ok) {
+      throw new Error(
+        `Datei-Download fehlgeschlagen (${response.status}) für ${document.fileName}`,
+      );
+    }
+
+    const documentBuffer = Buffer.from(await response.arrayBuffer());
+    const extractedText = await extractTextFromBytes(
+      document.fileName,
+      document.fileType,
+      documentBuffer,
+    );
+
+    if (!extractedText) {
+      throw new Error(
+        `Aus dieser Datei konnte kein Text extrahiert werden: ${document.fileName}`,
+      );
+    }
+
+    textOnlyDocuments.push({
+      fileName: document.fileName,
+      extractedText,
+    });
+
+    trace?.log("info", "model_input_text_fallback_extracted", {
+      fileName: document.fileName,
+      extractedLength: extractedText.length,
+      elapsedMs: Date.now() - textLoadStartedAt,
+    });
   }
 
   return {
@@ -1648,8 +1703,8 @@ export const extractDocumentContent = action({
     });
 
     // Hybrid approach:
-    // - Native Vertex file path for PDF/Slides/Word/Image formats.
-    // - officeparser/text extraction fallback for all other formats.
+    // - Native Vertex file path for PDF/image formats supported by Gemini.
+    // - officeparser/text extraction fallback for Office/text formats.
     if (isVertexNativeCandidate(document.fileType, document.fileName)) {
       trace.log("info", "skip_text_extraction_vertex_native", {
         fileName: document.fileName,

--- a/shared/uploadPolicy.ts
+++ b/shared/uploadPolicy.ts
@@ -20,10 +20,6 @@ export const ACCEPTED_UPLOAD_EXTENSIONS = [
 
 export const VERTEX_NATIVE_UPLOAD_EXTENSIONS = [
   "pdf",
-  "ppt",
-  "pptx",
-  "doc",
-  "docx",
   "jpg",
   "jpeg",
   "png",
@@ -32,10 +28,6 @@ export const VERTEX_NATIVE_UPLOAD_EXTENSIONS = [
 
 export const VERTEX_NATIVE_UPLOAD_MEDIA_TYPES = [
   "application/pdf",
-  "application/vnd.ms-powerpoint",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-  "application/msword",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   "image/jpeg",
   "image/png",
   "image/webp",


### PR DESCRIPTION
Summary
- update README to describe Vertex-only processing for supported image/PDF formats and text extraction fallback for Office/text documents
- improve document import flow by fetching storage URL, extracting text, and logging fallback steps when native parsing is unavailable
- limit Vertex native upload extensions/types to formats Gemini handles

Testing
- Not run (not requested)


https://github.com/user-attachments/assets/7bfa79eb-4fd0-4d84-9451-82fc3c7d6b8c

