### PR TITLE
Backfill grant identities for PostHog

### DIFF
--- a/convex/admin.test.ts
+++ b/convex/admin.test.ts
@@ -81,4 +81,118 @@ describe("convex/admin", () => {
     expect(deletedSession).toBeNull();
     expect(remainingSession?._id).toBe(secondSessionId);
   });
+
+  it("backfillt Legacy-Grants mit Fallback-Label sowie optionaler E-Mail und Notiz aus dem Zugangscode", async () => {
+    const t = createTestHarness();
+    const code = "grant-backfill-legacy";
+    const now = Date.now();
+
+    const { grantId } = await t.run(async (ctx) => {
+      await ctx.db.insert("accessCodes", {
+        code,
+        normalizedCode: normalizeAccessCode(code),
+        createdAt: now - 100,
+        consumedAt: now,
+        identityLabel: "  Jakob Rössner  ",
+        identityEmail: " Jakob.Roessner@Outlook.de ",
+        note: " Legacy-Hinweis ",
+        consumedByGrantId: await ctx.db.insert("accessGrants", {
+          token: "legacy-grant-token",
+          createdAt: now,
+        }),
+      });
+
+      const grant = await ctx.db
+        .query("accessGrants")
+        .withIndex("by_token", (q) => q.eq("token", "legacy-grant-token"))
+        .first();
+
+      if (!grant) {
+        throw new Error("Grant wurde nicht gefunden.");
+      }
+
+      return { grantId: grant._id };
+    });
+
+    const result = await t.mutation(api.admin.backfillGrantAnalyticsIdentity, {
+      adminSecret: "test-secret",
+      dryRun: false,
+      paginationOpts: {
+        cursor: null,
+        numItems: 10,
+      },
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      updated: 1,
+      labelsBackfilled: 1,
+      emailsBackfilled: 1,
+      notesBackfilled: 1,
+      skipped: 0,
+      isDone: true,
+    });
+    expect(result.samples).toHaveLength(1);
+    expect(result.samples[0]).toMatchObject({
+      grantId,
+      before: {},
+      after: {
+        identityLabel: "Jakob Rössner",
+        identityEmail: "jakob.roessner@outlook.de",
+        note: "Legacy-Hinweis",
+      },
+    });
+
+    const patchedGrant = await t.run(async (ctx) => ctx.db.get(grantId));
+
+    expect(patchedGrant).toMatchObject({
+      identityLabel: "Jakob Rössner",
+      identityEmail: "jakob.roessner@outlook.de",
+      note: "Legacy-Hinweis",
+    });
+  });
+
+  it("verwendet im Dry-Run ein deterministisches Fallback-Label ohne den Grant zu ändern", async () => {
+    const t = createTestHarness();
+    const now = Date.now();
+
+    const grantId = await t.run(async (ctx) =>
+      ctx.db.insert("accessGrants", {
+        token: "legacy-dry-run-token",
+        createdAt: now,
+      }),
+    );
+
+    const result = await t.mutation(api.admin.backfillGrantAnalyticsIdentity, {
+      adminSecret: "test-secret",
+      dryRun: true,
+      paginationOpts: {
+        cursor: null,
+        numItems: 10,
+      },
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      updated: 1,
+      labelsBackfilled: 1,
+      emailsBackfilled: 0,
+      notesBackfilled: 0,
+      skipped: 0,
+      isDone: true,
+    });
+    expect(result.samples[0]).toMatchObject({
+      grantId,
+      after: {
+        identityLabel: `Unbekannte Nutzerkennung (${grantId})`,
+      },
+    });
+
+    const unchangedGrant = await t.run(async (ctx) => ctx.db.get(grantId));
+
+    expect(unchangedGrant?.token).toBe("legacy-dry-run-token");
+    expect(unchangedGrant).not.toHaveProperty("identityLabel");
+    expect(unchangedGrant).not.toHaveProperty("identityEmail");
+    expect(unchangedGrant).not.toHaveProperty("note");
+  });
 });

--- a/convex/admin.test.ts
+++ b/convex/admin.test.ts
@@ -195,4 +195,74 @@ describe("convex/admin", () => {
     expect(unchangedGrant).not.toHaveProperty("identityEmail");
     expect(unchangedGrant).not.toHaveProperty("note");
   });
+
+  it("backfillt die E-Mail aus dem Zugangscode wenn der Grant nur Leerzeichen enthält", async () => {
+    const t = createTestHarness();
+    const code = "grant-backfill-email-whitespace";
+    const now = Date.now();
+
+    const { grantId } = await t.run(async (ctx) => {
+      await ctx.db.insert("accessCodes", {
+        code,
+        normalizedCode: normalizeAccessCode(code),
+        createdAt: now - 100,
+        consumedAt: now,
+        identityLabel: "Jakob Rössner",
+        identityEmail: " Jakob.Roessner@Outlook.de ",
+        consumedByGrantId: await ctx.db.insert("accessGrants", {
+          token: "legacy-whitespace-email-token",
+          createdAt: now,
+          identityLabel: "Jakob Rössner",
+          identityEmail: "   ",
+        }),
+      });
+
+      const grant = await ctx.db
+        .query("accessGrants")
+        .withIndex("by_token", (q) => q.eq("token", "legacy-whitespace-email-token"))
+        .first();
+
+      if (!grant) {
+        throw new Error("Grant wurde nicht gefunden.");
+      }
+
+      return { grantId: grant._id };
+    });
+
+    const result = await t.mutation(api.admin.backfillGrantAnalyticsIdentity, {
+      adminSecret: "test-secret",
+      dryRun: false,
+      paginationOpts: {
+        cursor: null,
+        numItems: 10,
+      },
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      updated: 1,
+      labelsBackfilled: 0,
+      emailsBackfilled: 1,
+      notesBackfilled: 0,
+      skipped: 0,
+    });
+    expect(result.samples[0]).toMatchObject({
+      grantId,
+      before: {
+        identityLabel: "Jakob Rössner",
+        identityEmail: "   ",
+      },
+      after: {
+        identityLabel: "Jakob Rössner",
+        identityEmail: "jakob.roessner@outlook.de",
+      },
+    });
+
+    const patchedGrant = await t.run(async (ctx) => ctx.db.get(grantId));
+
+    expect(patchedGrant).toMatchObject({
+      identityLabel: "Jakob Rössner",
+      identityEmail: "jakob.roessner@outlook.de",
+    });
+  });
 });

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -42,7 +42,8 @@ const normalizeOptionalIdentityEmail = (value: string | undefined) => {
     return undefined;
   }
 
-  return normalizeIdentityEmail(value);
+  const normalized = normalizeIdentityEmail(value);
+  return normalized ? normalized : undefined;
 };
 
 const normalizeOptionalNote = (value: string | undefined) => {

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -5,13 +5,50 @@ import {
   type MutationCtx,
   type QueryCtx,
 } from "./errorTracking";
+import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { assertAdminSecret } from "./adminAuth";
 import { deleteManagedFile } from "./fileStorage";
 import {
   assertMeaningfulIdentityLabel,
+  hasMeaningfulIdentityLabel,
   normalizeIdentityEmail,
+  normalizeIdentityLabel,
 } from "../shared/identity";
+
+const LEGACY_GRANT_IDENTITY_LABEL = "Unbekannte Nutzerkennung";
+const SAMPLE_LIMIT = 10;
+
+type BackfillSnapshot = {
+  identityLabel?: string;
+  identityEmail?: string;
+  note?: string;
+};
+
+const buildLegacyGrantIdentityLabel = (grantId: Id<"accessGrants">) =>
+  `${LEGACY_GRANT_IDENTITY_LABEL} (${grantId})`;
+
+const normalizeMeaningfulIdentityLabel = (value: string | undefined) => {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = normalizeIdentityLabel(value);
+  return hasMeaningfulIdentityLabel(normalized) ? normalized : undefined;
+};
+
+const normalizeOptionalIdentityEmail = (value: string | undefined) => {
+  if (!value) {
+    return undefined;
+  }
+
+  return normalizeIdentityEmail(value);
+};
+
+const normalizeOptionalNote = (value: string | undefined) => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
 
 const resolveTarget = async (
   ctx: QueryCtx | MutationCtx,
@@ -296,6 +333,158 @@ export const backfillQuizResponseMisunderstanding = mutation({
       scanned,
       patched,
       limit: effectiveLimit,
+    };
+  },
+});
+
+export const backfillGrantAnalyticsIdentity = mutation({
+  args: {
+    adminSecret: v.string(),
+    dryRun: v.optional(v.boolean()),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    assertAdminSecret(args.adminSecret);
+
+    const dryRun = args.dryRun ?? false;
+    const page = await ctx.db
+      .query("accessGrants")
+      .withIndex("by_createdAt")
+      .order("asc")
+      .paginate(args.paginationOpts);
+
+    let scanned = 0;
+    let updated = 0;
+    let labelsBackfilled = 0;
+    let emailsBackfilled = 0;
+    let notesBackfilled = 0;
+    let skipped = 0;
+    const samples: Array<{
+      grantId: string;
+      before: BackfillSnapshot;
+      after: BackfillSnapshot;
+    }> = [];
+    const incompleteSamples: Array<{
+      grantId: string;
+      reason: string;
+      before: BackfillSnapshot;
+      after: BackfillSnapshot;
+    }> = [];
+
+    for (const grant of page.page) {
+      scanned += 1;
+
+      const relatedAccessCode = await ctx.db
+        .query("accessCodes")
+        .withIndex("by_consumedByGrantId", (q) =>
+          q.eq("consumedByGrantId", grant._id),
+        )
+        .order("asc")
+        .first();
+
+      const before: BackfillSnapshot = {
+        identityLabel: grant.identityLabel,
+        identityEmail: grant.identityEmail,
+        note: grant.note,
+      };
+
+      const currentLabel = normalizeMeaningfulIdentityLabel(grant.identityLabel);
+      const accessCodeLabel = normalizeMeaningfulIdentityLabel(
+        relatedAccessCode?.identityLabel,
+      );
+      const nextLabel =
+        currentLabel ??
+        accessCodeLabel ??
+        buildLegacyGrantIdentityLabel(grant._id);
+
+      const currentEmail = normalizeOptionalIdentityEmail(grant.identityEmail);
+      const accessCodeEmail = normalizeOptionalIdentityEmail(
+        relatedAccessCode?.identityEmail,
+      );
+      const nextEmail = currentEmail ?? accessCodeEmail;
+
+      const currentNote = normalizeOptionalNote(grant.note);
+      const accessCodeNote = normalizeOptionalNote(relatedAccessCode?.note);
+      const nextNote = currentNote ?? accessCodeNote;
+
+      const patch: Record<string, string> = {};
+      let grantUpdated = false;
+
+      if (nextLabel !== grant.identityLabel) {
+        patch.identityLabel = nextLabel;
+        labelsBackfilled += 1;
+        grantUpdated = true;
+      }
+
+      if (nextEmail && nextEmail !== grant.identityEmail) {
+        patch.identityEmail = nextEmail;
+        emailsBackfilled += 1;
+        grantUpdated = true;
+      }
+
+      if (nextNote && nextNote !== grant.note) {
+        patch.note = nextNote;
+        notesBackfilled += 1;
+        grantUpdated = true;
+      }
+
+      const after: BackfillSnapshot = {
+        identityLabel: nextLabel,
+        ...(nextEmail ? { identityEmail: nextEmail } : {}),
+        ...(nextNote ? { note: nextNote } : {}),
+      };
+
+      if (!normalizeMeaningfulIdentityLabel(after.identityLabel)) {
+        if (incompleteSamples.length < SAMPLE_LIMIT) {
+          incompleteSamples.push({
+            grantId: grant._id,
+            reason: "identityLabel fehlt weiterhin",
+            before,
+            after,
+          });
+        }
+      }
+
+      if (!grantUpdated) {
+        skipped += 1;
+        continue;
+      }
+
+      if (!dryRun) {
+        await ctx.db.patch(grant._id, patch);
+      }
+
+      updated += 1;
+
+      if (samples.length < SAMPLE_LIMIT) {
+        samples.push({
+          grantId: grant._id,
+          before,
+          after,
+        });
+      }
+    }
+
+    if (incompleteSamples.length > 0) {
+      console.warn("Grant-Analytics-Backfill konnte nicht alle Felder füllen.", {
+        scanned,
+        updated,
+        incompleteSamples,
+      });
+    }
+
+    return {
+      scanned,
+      updated,
+      labelsBackfilled,
+      emailsBackfilled,
+      notesBackfilled,
+      skipped,
+      dryRun,
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+      samples,
+      incompleteSamples,
     };
   },
 });

--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -1149,6 +1149,34 @@ export const serializeAnalyticsMetadata = (
   return JSON.stringify(metadata);
 };
 
+export const resolvePostHogPersonProperties = (identity: {
+  analyticsGrantId?: string;
+  identityLabel?: string;
+  identityEmail?: string;
+  note?: string;
+  identityQuality?: string;
+}) => ({
+  ...(identity.analyticsGrantId
+    ? { analyticsGrantId: identity.analyticsGrantId }
+    : {}),
+  ...(identity.identityLabel
+    ? {
+        identityLabel: identity.identityLabel,
+        $name: identity.identityLabel,
+      }
+    : {}),
+  ...(identity.identityEmail
+    ? {
+        identityEmail: identity.identityEmail,
+        $email: identity.identityEmail,
+      }
+    : {}),
+  ...(identity.note ? { note: identity.note } : {}),
+  ...(identity.identityQuality
+    ? { identity_quality: identity.identityQuality }
+    : {}),
+});
+
 const stringifyForPostHog = (value: unknown) => {
   if (value === null || value === undefined) {
     return undefined;
@@ -1803,25 +1831,21 @@ const getGrantPostHogIdentity = async (
     },
   );
 
-  if (!identity.analyticsDistinctId || !identity.identityLabel) {
+  if (!identity.analyticsDistinctId) {
     return null;
   }
 
+  const personProperties = resolvePostHogPersonProperties({
+    analyticsGrantId: identity.analyticsGrantId,
+    identityLabel: identity.identityLabel,
+    identityEmail: identity.identityEmail,
+    note: identity.note,
+    identityQuality: identity.identityQuality,
+  });
+
   return {
     distinctId: identity.analyticsDistinctId,
-    personProperties: {
-      analyticsGrantId: identity.analyticsGrantId,
-      identityLabel: identity.identityLabel,
-      ...(identity.identityEmail
-        ? {
-            identityEmail: identity.identityEmail,
-            $email: identity.identityEmail,
-          }
-        : {}),
-      ...(identity.note ? { note: identity.note } : {}),
-      identity_quality: identity.identityQuality,
-      $name: identity.identityLabel,
-    },
+    ...(Object.keys(personProperties).length > 0 ? { personProperties } : {}),
   };
 };
 

--- a/convex/aiAnalyticsMetadata.test.ts
+++ b/convex/aiAnalyticsMetadata.test.ts
@@ -1,7 +1,10 @@
 import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 import { api, internal } from "./_generated/api";
-import { serializeAnalyticsMetadata } from "./ai";
+import {
+  resolvePostHogPersonProperties,
+  serializeAnalyticsMetadata,
+} from "./ai";
 import schema from "./schema";
 import { modules } from "./test.setup";
 
@@ -58,6 +61,38 @@ describe("convex/ai analytics metadata contract", () => {
     expect(serialized).toBeDefined();
     expect(JSON.parse(serialized ?? "null")).toEqual(metadata);
     expect(serialized).toContain(`"longText":"${"x".repeat(600)}"`);
+  });
+
+  it("erstellt PostHog-Person-Properties auch ohne identityLabel nur aus vorhandenen Feldern", () => {
+    expect(
+      resolvePostHogPersonProperties({
+        analyticsGrantId: "grant-123",
+        identityQuality: "app_only",
+      }),
+    ).toEqual({
+      analyticsGrantId: "grant-123",
+      identity_quality: "app_only",
+    });
+  });
+
+  it("erstellt vollständige PostHog-Person-Properties wenn Label und E-Mail vorhanden sind", () => {
+    expect(
+      resolvePostHogPersonProperties({
+        analyticsGrantId: "grant-123",
+        identityLabel: "Jakob Rössner",
+        identityEmail: "jakob.roessner@outlook.de",
+        note: "Der Beste",
+        identityQuality: "email",
+      }),
+    ).toEqual({
+      analyticsGrantId: "grant-123",
+      identityLabel: "Jakob Rössner",
+      identityEmail: "jakob.roessner@outlook.de",
+      note: "Der Beste",
+      identity_quality: "email",
+      $name: "Jakob Rössner",
+      $email: "jakob.roessner@outlook.de",
+    });
   });
 
   it("liefert rohe metadataJson-Werte über die Session-Analytics-Abfrage zurück", async () => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -52,7 +52,9 @@ export default defineSchema({
     identityLabel: v.optional(v.string()),
     identityEmail: v.optional(v.string()),
     note: v.optional(v.string()),
-  }).index("by_normalizedCode", ["normalizedCode"]),
+  })
+    .index("by_normalizedCode", ["normalizedCode"])
+    .index("by_consumedByGrantId", ["consumedByGrantId"]),
 
   /** Aktive Zugriffsberechtigungen (Tokens), die einem Browser zugeordnet sind */
   accessGrants: defineTable({
@@ -62,7 +64,9 @@ export default defineSchema({
     identityEmail: v.optional(v.string()),
     note: v.optional(v.string()),
     revokedAt: v.optional(v.number()),
-  }).index("by_token", ["token"]),
+  })
+    .index("by_token", ["token"])
+    .index("by_createdAt", ["createdAt"]),
 
   /** Eine Lern-Sitzung, die mehrere Dokumente und mehrere Quiz-Batches umfasst. */
   studySessions: defineTable({


### PR DESCRIPTION
- backfill legacy access grants with fallback labels, email, and notes
- decouple PostHog person properties from requiring identity labels
- add coverage for backfill and property resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin mutation to backfill and normalize grant analytics identity data with dry-run support and sampling for review.
  * Improved analytics identity resolution to produce richer PostHog person properties (name, email, note, quality).

* **Tests**
  * Added tests covering backfill behaviors (dry-run, normalization, email-only) and PostHog property mapping.

* **Chores**
  * Added indexes to optimize analytics-related queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/smartnotes-germany/smartnotes-mvp/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
