### PR TITLE
Add source Context to PDFs

### DIFF
--- a/.agents/skills/convex-create-component/SKILL.md
+++ b/.agents/skills/convex-create-component/SKILL.md
@@ -42,12 +42,12 @@ Create reusable Convex components with clear boundaries and a small app-facing A
 
 Ask the user, then pick one path:
 
-| Goal | Shape | Reference |
-|------|-------|-----------|
-| Component for this app only | Local | `references/local-components.md` |
-| Publish or share across apps | Packaged | `references/packaged-components.md` |
-| User explicitly needs local + shared library code | Hybrid | `references/hybrid-components.md` |
-| Not sure | Default to local | `references/local-components.md` |
+| Goal                                              | Shape            | Reference                           |
+| ------------------------------------------------- | ---------------- | ----------------------------------- |
+| Component for this app only                       | Local            | `references/local-components.md`    |
+| Publish or share across apps                      | Packaged         | `references/packaged-components.md` |
+| User explicitly needs local + shared library code | Hybrid           | `references/hybrid-components.md`   |
+| Not sure                                          | Default to local | `references/local-components.md`    |
 
 Read exactly one reference file before proceeding.
 
@@ -111,7 +111,7 @@ export const listUnread = query({
       userId: v.string(),
       message: v.string(),
       read: v.boolean(),
-    })
+    }),
   ),
   handler: async (ctx, args) => {
     return await ctx.db
@@ -234,12 +234,16 @@ export const sendNotification = mutation({
 
 ```ts
 // Bad: parent app table IDs are not valid component validators
-args: { userId: v.id("users") }
+args: {
+  userId: v.id("users");
+}
 ```
 
 ```ts
 // Good: treat parent-owned IDs as strings at the boundary
-args: { userId: v.string() }
+args: {
+  userId: v.string();
+}
 ```
 
 ### Advanced Patterns

--- a/.agents/skills/convex-migration-helper/SKILL.md
+++ b/.agents/skills/convex-migration-helper/SKILL.md
@@ -55,13 +55,13 @@ Unless you are certain, prefer deprecating fields over deleting them. Mark the f
 // Before
 users: defineTable({
   name: v.string(),
-})
+});
 
 // After - safe, new field is optional
 users: defineTable({
   name: v.string(),
   bio: v.optional(v.string()),
-})
+});
 ```
 
 ### Adding New Table
@@ -70,7 +70,7 @@ users: defineTable({
 posts: defineTable({
   userId: v.id("users"),
   title: v.string(),
-}).index("by_user", ["userId"])
+}).index("by_user", ["userId"]);
 ```
 
 ### Adding Index
@@ -79,8 +79,7 @@ posts: defineTable({
 users: defineTable({
   name: v.string(),
   email: v.string(),
-})
-  .index("by_email", ["email"])
+}).index("by_email", ["email"]);
 ```
 
 ## Breaking Changes: The Deployment Workflow

--- a/.agents/skills/convex-migration-helper/references/migration-patterns.md
+++ b/.agents/skills/convex-migration-helper/references/migration-patterns.md
@@ -9,7 +9,7 @@ Common migration patterns, zero-downtime strategies, and verification techniques
 users: defineTable({
   name: v.string(),
   role: v.optional(v.union(v.literal("user"), v.literal("admin"))),
-})
+});
 
 // Migration: backfill the field
 export const addDefaultRole = migrations.define({
@@ -25,7 +25,7 @@ export const addDefaultRole = migrations.define({
 users: defineTable({
   name: v.string(),
   role: v.union(v.literal("user"), v.literal("admin")),
-})
+});
 ```
 
 ## Deleting a Field

--- a/.agents/skills/convex-migration-helper/references/migrations-component.md
+++ b/.agents/skills/convex-migration-helper/references/migrations-component.md
@@ -151,8 +151,7 @@ Process only matching documents instead of the full table:
 ```typescript
 export const fixEmptyNames = migrations.define({
   table: "users",
-  customRange: (query) =>
-    query.withIndex("by_name", (q) => q.eq("name", "")),
+  customRange: (query) => query.withIndex("by_name", (q) => q.eq("name", "")),
   migrateOne: () => ({ name: "<unknown>" }),
 });
 ```

--- a/.agents/skills/convex-performance-audit/SKILL.md
+++ b/.agents/skills/convex-performance-audit/SKILL.md
@@ -43,13 +43,13 @@ Start with the strongest signal available:
 
 After gathering signals, identify the problem class and read the matching reference file.
 
-| Signal | Reference |
-|---|---|
-| High bytes or documents read, JS filtering, unnecessary joins | `references/hot-path-rules.md` |
-| OCC conflict errors, write contention, mutation retries | `references/occ-conflicts.md` |
-| High subscription count, slow UI updates, excessive re-renders | `references/subscription-cost.md` |
-| Function timeouts, transaction size errors, large payloads | `references/function-budget.md` |
-| General "it's slow" with no specific signal | Start with `references/hot-path-rules.md` |
+| Signal                                                         | Reference                                 |
+| -------------------------------------------------------------- | ----------------------------------------- |
+| High bytes or documents read, JS filtering, unnecessary joins  | `references/hot-path-rules.md`            |
+| OCC conflict errors, write contention, mutation retries        | `references/occ-conflicts.md`             |
+| High subscription count, slow UI updates, excessive re-renders | `references/subscription-cost.md`         |
+| Function timeouts, transaction size errors, large payloads     | `references/function-budget.md`           |
+| General "it's slow" with no specific signal                    | Start with `references/hot-path-rules.md` |
 
 Multiple problem classes can overlap. Read the most relevant reference first, then check the others if symptoms remain.
 

--- a/.agents/skills/convex-performance-audit/references/function-budget.md
+++ b/.agents/skills/convex-performance-audit/references/function-budget.md
@@ -10,17 +10,17 @@ Convex functions run inside transactions with budgets for time, reads, and write
 
 These are the current values from the [Convex limits docs](https://docs.convex.dev/production/state/limits). Check that page for the latest numbers.
 
-| Resource | Limit |
-|---|---|
-| Query/mutation execution time | 1 second (user code only, excludes DB operations) |
-| Action execution time | 10 minutes |
-| Data read per transaction | 16 MiB |
-| Data written per transaction | 16 MiB |
+| Resource                          | Limit                                                 |
+| --------------------------------- | ----------------------------------------------------- |
+| Query/mutation execution time     | 1 second (user code only, excludes DB operations)     |
+| Action execution time             | 10 minutes                                            |
+| Data read per transaction         | 16 MiB                                                |
+| Data written per transaction      | 16 MiB                                                |
 | Documents scanned per transaction | 32,000 (includes documents filtered out by `.filter`) |
-| Index ranges read per transaction | 4,096 (each `db.get` and `db.query` call) |
-| Documents written per transaction | 16,000 |
-| Individual document size | 1 MiB |
-| Function return value size | 16 MiB |
+| Index ranges read per transaction | 4,096 (each `db.get` and `db.query` call)             |
+| Documents written per transaction | 16,000                                                |
+| Individual document size          | 1 MiB                                                 |
+| Function return value size        | 16 MiB                                                |
 
 ## Symptoms
 

--- a/.agents/skills/convex-performance-audit/references/hot-path-rules.md
+++ b/.agents/skills/convex-performance-audit/references/hot-path-rules.md
@@ -121,13 +121,15 @@ Indexes like `by_foo` and `by_foo_and_bar` are usually redundant. You only need 
 // Bad: two indexes where one would do
 defineTable({ team: v.id("teams"), user: v.id("users") })
   .index("by_team", ["team"])
-  .index("by_team_and_user", ["team", "user"])
+  .index("by_team_and_user", ["team", "user"]);
 ```
 
 ```ts
 // Good: single compound index serves both query patterns
-defineTable({ team: v.id("teams"), user: v.id("users") })
-  .index("by_team_and_user", ["team", "user"])
+defineTable({ team: v.id("teams"), user: v.id("users") }).index(
+  "by_team_and_user",
+  ["team", "user"],
+);
 ```
 
 Exception: `.index("by_foo", ["foo"])` is really an index on `foo` + `_creationTime`, while `.index("by_foo_and_bar", ["foo", "bar"])` is on `foo` + `bar` + `_creationTime`. If you need results sorted by `foo` then `_creationTime`, you need the single-field index because the compound one would sort by `bar` first.
@@ -170,9 +172,7 @@ const ownerName = project.ownerName ?? "Unknown owner";
 ```ts
 // Good: denormalized data is an optimization, not the only source of truth
 const ownerName =
-  project.ownerName ??
-  (await ctx.db.get(project.ownerId))?.name ??
-  null;
+  project.ownerName ?? (await ctx.db.get(project.ownerId))?.name ?? null;
 ```
 
 Bad lookup map pattern:

--- a/.agents/skills/convex-quickstart/SKILL.md
+++ b/.agents/skills/convex-quickstart/SKILL.md
@@ -32,15 +32,15 @@ Use the official scaffolding tool. It creates a complete project with the fronte
 
 ### Pick a template
 
-| Template | Stack |
-|----------|-------|
-| `react-vite-shadcn` | React + Vite + Tailwind + shadcn/ui |
-| `nextjs-shadcn` | Next.js App Router + Tailwind + shadcn/ui |
-| `react-vite-clerk-shadcn` | React + Vite + Clerk auth + shadcn/ui |
-| `nextjs-clerk` | Next.js + Clerk auth |
-| `nextjs-convexauth-shadcn` | Next.js + Convex Auth + shadcn/ui |
-| `nextjs-lucia-shadcn` | Next.js + Lucia auth + shadcn/ui |
-| `bare` | Convex backend only, no frontend |
+| Template                   | Stack                                     |
+| -------------------------- | ----------------------------------------- |
+| `react-vite-shadcn`        | React + Vite + Tailwind + shadcn/ui       |
+| `nextjs-shadcn`            | Next.js App Router + Tailwind + shadcn/ui |
+| `react-vite-clerk-shadcn`  | React + Vite + Clerk auth + shadcn/ui     |
+| `nextjs-clerk`             | Next.js + Clerk auth                      |
+| `nextjs-convexauth-shadcn` | Next.js + Convex Auth + shadcn/ui         |
+| `nextjs-lucia-shadcn`      | Next.js + Lucia auth + shadcn/ui          |
+| `bare`                     | Convex backend only, no frontend          |
 
 If the user has not specified a preference, default to `react-vite-shadcn` for simple apps or `nextjs-shadcn` for apps that need SSR or API routes.
 
@@ -77,6 +77,7 @@ npm install
 **Ask the user to run this themselves:**
 
 Tell the user to run `npx convex dev` in their terminal. On first run it will prompt them to log in or develop anonymously. Once running, it will:
+
 - Create a Convex project and dev deployment
 - Write the deployment URL to `.env.local`
 - Create the `convex/` directory with generated types
@@ -111,6 +112,7 @@ my-app/
 ```
 
 The template already has:
+
 - `ConvexProvider` wired into the app root
 - Correct env var names for the framework
 - Tailwind and shadcn/ui ready (for shadcn templates)
@@ -141,7 +143,9 @@ Create the `ConvexReactClient` at module scope, not inside a component:
 ```tsx
 // Bad: re-creates the client on every render
 function App() {
-  const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
+  const convex = new ConvexReactClient(
+    import.meta.env.VITE_CONVEX_URL as string,
+  );
   return <ConvexProvider client={convex}>...</ConvexProvider>;
 }
 
@@ -192,7 +196,11 @@ export function ConvexClientProvider({ children }: { children: ReactNode }) {
 // app/layout.tsx
 import { ConvexClientProvider } from "./ConvexClientProvider";
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="en">
       <body>
@@ -218,11 +226,11 @@ For Vue, Svelte, React Native, TanStack Start, Remix, and others, follow the mat
 
 The env var name depends on the framework:
 
-| Framework | Variable |
-|-----------|----------|
-| Vite | `VITE_CONVEX_URL` |
-| Next.js | `NEXT_PUBLIC_CONVEX_URL` |
-| Remix | `CONVEX_URL` |
+| Framework    | Variable                 |
+| ------------ | ------------------------ |
+| Vite         | `VITE_CONVEX_URL`        |
+| Next.js      | `NEXT_PUBLIC_CONVEX_URL` |
+| Remix        | `CONVEX_URL`             |
 | React Native | `EXPO_PUBLIC_CONVEX_URL` |
 
 `npx convex dev` writes the correct variable to `.env.local` automatically.
@@ -299,7 +307,9 @@ function Tasks() {
   return (
     <div>
       <button onClick={() => create({ text: "New task" })}>Add</button>
-      {tasks?.map((t) => <div key={t._id}>{t.text}</div>)}
+      {tasks?.map((t) => (
+        <div key={t._id}>{t.text}</div>
+      ))}
     </div>
   );
 }

--- a/.agents/skills/convex-setup-auth/SKILL.md
+++ b/.agents/skills/convex-setup-auth/SKILL.md
@@ -102,7 +102,7 @@ export const getMyProfile = query({
     return await ctx.db
       .query("users")
       .withIndex("by_tokenIdentifier", (q) =>
-        q.eq("tokenIdentifier", identity.tokenIdentifier)
+        q.eq("tokenIdentifier", identity.tokenIdentifier),
       )
       .unique();
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,11 @@ Don't use workarounds like ae, oe, ue, but use the proper German "Umlaute" (ä, 
 Run `pnpm lint`, `pnpm format:check`, `pnpm build` and `pnpm knip` after making changes to ensure code quality.
 
 <!-- convex-ai-start -->
+
 This project uses [Convex](https://convex.dev) as its backend.
 
 When working on Convex code, **always read `convex/_generated/ai/guidelines.md` first** for important guidelines on how to correctly use Convex APIs and patterns. The file contains rules that override what you may have learned about Convex from training data.
 
 Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
+
 <!-- convex-ai-end -->

--- a/convex/_generated/ai/guidelines.md
+++ b/convex/_generated/ai/guidelines.md
@@ -1,78 +1,90 @@
 # Convex guidelines
+
 ## Function guidelines
+
 ### Http endpoint syntax
+
 - HTTP endpoints are defined in `convex/http.ts` and require an `httpAction` decorator. For example:
+
 ```typescript
 import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server";
 const http = httpRouter();
 http.route({
-    path: "/echo",
-    method: "POST",
-    handler: httpAction(async (ctx, req) => {
+  path: "/echo",
+  method: "POST",
+  handler: httpAction(async (ctx, req) => {
     const body = await req.bytes();
     return new Response(body, { status: 200 });
-    }),
+  }),
 });
 ```
+
 - HTTP endpoints are always registered at the exact path you specify in the `path` field. For example, if you specify `/api/someRoute`, the endpoint will be registered at `/api/someRoute`.
 
 ### Validators
+
 - Below is an example of an array validator:
+
 ```typescript
 import { mutation } from "./_generated/server";
 import { v } from "convex/values";
 
 export default mutation({
-args: {
+  args: {
     simpleArray: v.array(v.union(v.string(), v.number())),
-},
-handler: async (ctx, args) => {
+  },
+  handler: async (ctx, args) => {
     //...
-},
+  },
 });
 ```
+
 - Below is an example of a schema with validators that codify a discriminated union type:
+
 ```typescript
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
-    results: defineTable(
-        v.union(
-            v.object({
-                kind: v.literal("error"),
-                errorMessage: v.string(),
-            }),
-            v.object({
-                kind: v.literal("success"),
-                value: v.number(),
-            }),
-        ),
-    )
+  results: defineTable(
+    v.union(
+      v.object({
+        kind: v.literal("error"),
+        errorMessage: v.string(),
+      }),
+      v.object({
+        kind: v.literal("success"),
+        value: v.number(),
+      }),
+    ),
+  ),
 });
 ```
+
 - Here are the valid Convex types along with their respective validators:
-Convex Type  | TS/JS type  |  Example Usage         | Validator for argument validation and schemas  | Notes                                                                                                                                                                                                 |
-| ----------- | ------------| -----------------------| -----------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Id          | string      | `doc._id`              | `v.id(tableName)`                              |                                                                                                                                                                                                       |
-| Null        | null        | `null`                 | `v.null()`                                     | JavaScript's `undefined` is not a valid Convex value. Functions the return `undefined` or do not return will return `null` when called from a client. Use `null` instead.                             |
-| Int64       | bigint      | `3n`                   | `v.int64()`                                    | Int64s only support BigInts between -2^63 and 2^63-1. Convex supports `bigint`s in most modern browsers.                                                                                              |
-| Float64     | number      | `3.1`                  | `v.number()`                                   | Convex supports all IEEE-754 double-precision floating point numbers (such as NaNs). Inf and NaN are JSON serialized as strings.                                                                      |
-| Boolean     | boolean     | `true`                 | `v.boolean()`                                  |
-| String      | string      | `"abc"`                | `v.string()`                                   | Strings are stored as UTF-8 and must be valid Unicode sequences. Strings must be smaller than the 1MB total size limit when encoded as UTF-8.                                                         |
-| Bytes       | ArrayBuffer | `new ArrayBuffer(8)`   | `v.bytes()`                                    | Convex supports first class bytestrings, passed in as `ArrayBuffer`s. Bytestrings must be smaller than the 1MB total size limit for Convex types.                                                     |
-| Array       | Array       | `[1, 3.2, "abc"]`      | `v.array(values)`                              | Arrays can have at most 8192 values.                                                                                                                                                                  |
-| Object      | Object      | `{a: "abc"}`           | `v.object({property: value})`                  | Convex only supports "plain old JavaScript objects" (objects that do not have a custom prototype). Objects can have at most 1024 entries. Field names must be nonempty and not start with "$" or "_". |
-| Record      | Record      | `{"a": "1", "b": "2"}` | `v.record(keys, values)`                       | Records are objects at runtime, but can have dynamic keys. Keys must be only ASCII characters, nonempty, and not start with "$" or "_".                                                               |
+  Convex Type | TS/JS type | Example Usage | Validator for argument validation and schemas | Notes |
+  | ----------- | ------------| -----------------------| -----------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | Id | string | `doc._id` | `v.id(tableName)` | |
+  | Null | null | `null` | `v.null()` | JavaScript's `undefined` is not a valid Convex value. Functions the return `undefined` or do not return will return `null` when called from a client. Use `null` instead. |
+  | Int64 | bigint | `3n` | `v.int64()` | Int64s only support BigInts between -2^63 and 2^63-1. Convex supports `bigint`s in most modern browsers. |
+  | Float64 | number | `3.1` | `v.number()` | Convex supports all IEEE-754 double-precision floating point numbers (such as NaNs). Inf and NaN are JSON serialized as strings. |
+  | Boolean | boolean | `true` | `v.boolean()` |
+  | String | string | `"abc"` | `v.string()` | Strings are stored as UTF-8 and must be valid Unicode sequences. Strings must be smaller than the 1MB total size limit when encoded as UTF-8. |
+  | Bytes | ArrayBuffer | `new ArrayBuffer(8)` | `v.bytes()` | Convex supports first class bytestrings, passed in as `ArrayBuffer`s. Bytestrings must be smaller than the 1MB total size limit for Convex types. |
+  | Array | Array | `[1, 3.2, "abc"]` | `v.array(values)` | Arrays can have at most 8192 values. |
+  | Object | Object | `{a: "abc"}` | `v.object({property: value})` | Convex only supports "plain old JavaScript objects" (objects that do not have a custom prototype). Objects can have at most 1024 entries. Field names must be nonempty and not start with "$" or "_". |
+| Record      | Record      | `{"a": "1", "b": "2"}` | `v.record(keys, values)`                       | Records are objects at runtime, but can have dynamic keys. Keys must be only ASCII characters, nonempty, and not start with "$" or "\_". |
 
 ### Function registration
+
 - Use `internalQuery`, `internalMutation`, and `internalAction` to register internal functions. These functions are private and aren't part of an app's API. They can only be called by other Convex functions. These functions are always imported from `./_generated/server`.
 - Use `query`, `mutation`, and `action` to register public functions. These functions are part of the public API and are exposed to the public Internet. Do NOT use `query`, `mutation`, or `action` to register sensitive internal functions that should be kept private.
 - You CANNOT register a function through the `api` or `internal` objects.
 - ALWAYS include argument validators for all Convex functions. This includes all of `query`, `internalQuery`, `mutation`, `internalMutation`, `action`, and `internalAction`.
 
 ### Function calling
+
 - Use `ctx.runQuery` to call a query from a query, mutation, or action.
 - Use `ctx.runMutation` to call a mutation from a mutation or action.
 - Use `ctx.runAction` to call an action from an action.
@@ -80,6 +92,7 @@ Convex Type  | TS/JS type  |  Example Usage         | Validator for argument val
 - Try to use as few calls from actions to queries and mutations as possible. Queries and mutations are transactions, so splitting logic up into multiple calls introduces the risk of race conditions.
 - All of these calls take in a `FunctionReference`. Do NOT try to pass the callee function directly into one of these calls.
 - When using `ctx.runQuery`, `ctx.runMutation`, or `ctx.runAction` to call a function in the same file, specify a type annotation on the return value to work around TypeScript circularity limitations. For example,
+
 ```
 export const f = query({
   args: { name: v.string() },
@@ -98,6 +111,7 @@ export const g = query({
 ```
 
 ### Function references
+
 - Use the `api` object defined by the framework in `convex/_generated/api.ts` to call public functions registered with `query`, `mutation`, or `action`.
 - Use the `internal` object defined by the framework in `convex/_generated/api.ts` to call internal (or private) functions registered with `internalQuery`, `internalMutation`, or `internalAction`.
 - Convex uses file-based routing, so a public function defined in `convex/example.ts` named `f` has a function reference of `api.example.f`.
@@ -105,6 +119,7 @@ export const g = query({
 - Functions can also registered within directories nested within the `convex/` folder. For example, a public function `h` defined in `convex/messages/access.ts` has a function reference of `api.messages.access.h`.
 
 ### Pagination
+
 - Define pagination using the following syntax:
 
 ```ts
@@ -112,17 +127,19 @@ import { v } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { paginationOptsValidator } from "convex/server";
 export const listWithExtraArg = query({
-    args: { paginationOpts: paginationOptsValidator, author: v.string() },
-    handler: async (ctx, args) => {
-        return await ctx.db
-        .query("messages")
-        .withIndex("by_author", (q) => q.eq("author", args.author))
-        .order("desc")
-        .paginate(args.paginationOpts);
-    },
+  args: { paginationOpts: paginationOptsValidator, author: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("messages")
+      .withIndex("by_author", (q) => q.eq("author", args.author))
+      .order("desc")
+      .paginate(args.paginationOpts);
+  },
 });
 ```
+
 Note: `paginationOpts` is an object with the following properties:
+
 - `numItems`: the maximum number of documents to return (the validator is `v.number()`)
 - `cursor`: the cursor to use to fetch the next page of documents (the validator is `v.union(v.string(), v.null())`)
 - A query that ends in `.paginate()` returns an object that has the following properties:
@@ -130,8 +147,8 @@ Note: `paginationOpts` is an object with the following properties:
 - isDone (a boolean that represents whether or not this is the last page of documents)
 - continueCursor (a string that represents the cursor to use to fetch the next page of documents)
 
-
 ## Schema guidelines
+
 - Always define your schema in `convex/schema.ts`.
 - Always import the schema definition functions from `convex/server`.
 - System fields are automatically added to all documents and are prefixed with an underscore. The two system fields that are automatically added to all documents are `_creationTime` which has the validator `v.number()` and `_id` which has the validator `v.id(tableName)`.
@@ -141,8 +158,10 @@ Note: `paginationOpts` is an object with the following properties:
 - Separate high-churn operational data (e.g. heartbeats, online status, typing indicators) from stable profile data. Storing frequently updated fields on a shared document forces every write to contend with reads of the entire document. Instead, create a dedicated table for the high-churn data with a foreign key back to the parent record.
 
 ## Authentication guidelines
+
 - Convex supports JWT-based authentication through `convex/auth.config.ts`. ALWAYS create this file when using authentication. Without it, `ctx.auth.getUserIdentity()` will always return `null`.
 - Example `convex/auth.config.ts`:
+
 ```typescript
 export default {
   providers: [
@@ -153,11 +172,14 @@ export default {
   ],
 };
 ```
+
 The `domain` must be the issuer URL of the JWT provider. Convex fetches `{domain}/.well-known/openid-configuration` to discover the JWKS endpoint. The `applicationID` is checked against the JWT `aud` (audience) claim.
+
 - Use `ctx.auth.getUserIdentity()` to get the authenticated user's identity in any query, mutation, or action. This returns `null` if the user is not authenticated, or a `UserIdentity` object with fields like `subject`, `issuer`, `name`, `email`, etc. The `subject` field is the unique user identifier.
 - In Convex `UserIdentity`, `tokenIdentifier` is guaranteed and is the canonical stable identifier for the authenticated identity. For any auth-linked database lookup or ownership check, prefer `identity.tokenIdentifier` over `identity.subject`. Do NOT use `identity.subject` alone as a global identity key.
 - NEVER accept a `userId` or any user identifier as a function argument for authorization purposes. Always derive the user identity server-side via `ctx.auth.getUserIdentity()`.
 - When using an external auth provider with Convex on the client, use `ConvexProviderWithAuth` instead of `ConvexProvider`:
+
 ```tsx
 import { ConvexProviderWithAuth, ConvexReactClient } from "convex/react";
 
@@ -171,45 +193,51 @@ function App({ children }: { children: React.ReactNode }) {
   );
 }
 ```
+
 The `useAuth` prop must return `{ isLoading, isAuthenticated, fetchAccessToken }`. Do NOT use plain `ConvexProvider` when authentication is needed — it will not send tokens with requests.
 
 ## Typescript guidelines
-- You can use the helper typescript type `Id` imported from './_generated/dataModel' to get the type of the id for a given table. For example if there is a table called 'users' you can use `Id<'users'>` to get the type of the id for that table.
+
+- You can use the helper typescript type `Id` imported from './\_generated/dataModel' to get the type of the id for a given table. For example if there is a table called 'users' you can use `Id<'users'>` to get the type of the id for that table.
 - Use `Doc<"tableName">` from `./_generated/dataModel` to get the full document type for a table.
 - Use `QueryCtx`, `MutationCtx`, `ActionCtx` from `./_generated/server` for typing function contexts. NEVER use `any` for ctx parameters — always use the proper context type.
 - If you need to define a `Record` make sure that you correctly provide the type of the key and value in the type. For example a validator `v.record(v.id('users'), v.string())` would have the type `Record<Id<'users'>, string>`. Below is an example of using `Record` with an `Id` type in a query:
+
 ```ts
 import { query } from "./_generated/server";
 import { Doc, Id } from "./_generated/dataModel";
 
 export const exampleQuery = query({
-    args: { userIds: v.array(v.id("users")) },
-    handler: async (ctx, args) => {
-        const idToUsername: Record<Id<"users">, string> = {};
-        for (const userId of args.userIds) {
-            const user = await ctx.db.get("users", userId);
-            if (user) {
-                idToUsername[user._id] = user.username;
-            }
-        }
+  args: { userIds: v.array(v.id("users")) },
+  handler: async (ctx, args) => {
+    const idToUsername: Record<Id<"users">, string> = {};
+    for (const userId of args.userIds) {
+      const user = await ctx.db.get("users", userId);
+      if (user) {
+        idToUsername[user._id] = user.username;
+      }
+    }
 
-        return idToUsername;
-    },
+    return idToUsername;
+  },
 });
 ```
+
 - Be strict with types, particularly around id's of documents. For example, if a function takes in an id for a document in the 'users' table, take in `Id<'users'>` rather than `string`.
 
 ## Full text search guidelines
+
 - A query for "10 messages in channel '#general' that best match the query 'hello hi' in their body" would look like:
 
 const messages = await ctx.db
-  .query("messages")
-  .withSearchIndex("search_body", (q) =>
-    q.search("body", "hello hi").eq("channel", "#general"),
-  )
-  .take(10);
+.query("messages")
+.withSearchIndex("search_body", (q) =>
+q.search("body", "hello hi").eq("channel", "#general"),
+)
+.take(10);
 
 ## Query guidelines
+
 - Do NOT use `filter` in queries. Instead, define an index in the schema and use `withIndex` instead.
 - If the user does not explicitly tell you to return all results from a query you should ALWAYS return a bounded collection instead. So that is instead of using `.collect()` you should use `.take()` or paginate on database queries. This prevents future performance issues when tables grow in an unbounded way.
 - Never use `.collect().length` to count rows. Convex has no built-in count operator, so if you need a count that stays efficient at scale, maintain a denormalized counter in a separate document and update it in your mutations.
@@ -217,39 +245,46 @@ const messages = await ctx.db
 - Convex mutations are transactions with limits on the number of documents read and written. If a mutation needs to process more documents than fit in a single transaction (e.g. bulk deletion on a large table), process a batch with `.take(n)` and then call `ctx.scheduler.runAfter(0, api.myModule.myMutation, args)` to schedule itself to continue. This way each invocation stays within transaction limits.
 - Use `.unique()` to get a single document from a query. This method will throw an error if there are multiple documents that match the query.
 - When using async iteration, don't use `.collect()` or `.take(n)` on the result of a query. Instead, use the `for await (const row of query)` syntax.
+
 ### Ordering
+
 - By default Convex always returns documents in ascending `_creationTime` order.
 - You can use `.order('asc')` or `.order('desc')` to pick whether a query is in ascending or descending order. If the order isn't specified, it defaults to ascending.
 - Document queries that use indexes will be ordered based on the columns in the index and can avoid slow table scans.
 
-
 ## Mutation guidelines
+
 - Use `ctx.db.replace` to fully replace an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.replace('tasks', taskId, { name: 'Buy milk', completed: false })`
 - Use `ctx.db.patch` to shallow merge updates into an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.patch('tasks', taskId, { completed: true })`
 
 ## Action guidelines
+
 - Always add `"use node";` to the top of files containing actions that use Node.js built-in modules.
 - Never add `"use node";` to a file that also exports queries or mutations. Only actions can run in the Node.js runtime; queries and mutations must stay in the default Convex runtime. If you need Node.js built-ins alongside queries or mutations, put the action in a separate file.
 - `fetch()` is available in the default Convex runtime. You do NOT need `"use node";` just to use `fetch()`.
 - Never use `ctx.db` inside of an action. Actions don't have access to the database.
 - Below is an example of the syntax for an action:
+
 ```ts
 import { action } from "./_generated/server";
 
 export const exampleAction = action({
-    args: {},
-    handler: async (ctx, args) => {
-        console.log("This action does not return anything");
-        return null;
-    },
+  args: {},
+  handler: async (ctx, args) => {
+    console.log("This action does not return anything");
+    return null;
+  },
 });
 ```
 
 ## Scheduling guidelines
+
 ### Cron guidelines
+
 - Only use the `crons.interval` or `crons.cron` methods to schedule cron jobs. Do NOT use the `crons.hourly`, `crons.daily`, or `crons.weekly` helpers.
 - Both cron methods take in a FunctionReference. Do NOT try to pass the function directly into one of these methods.
 - Define crons by declaring the top-level `crons` object, calling some methods on it, and then exporting it as default. For example,
+
 ```ts
 import { cronJobs } from "convex/server";
 import { internal } from "./_generated/api";
@@ -269,14 +304,16 @@ crons.interval("delete inactive users", { hours: 2 }, internal.crons.empty, {});
 
 export default crons;
 ```
-- You can register Convex functions within `crons.ts` just like any other file.
-- If a cron calls an internal function, always import the `internal` object from '_generated/api', even if the internal function is registered in the same file.
 
+- You can register Convex functions within `crons.ts` just like any other file.
+- If a cron calls an internal function, always import the `internal` object from '\_generated/api', even if the internal function is registered in the same file.
 
 ## Testing guidelines
+
 - Use `convex-test` with `vitest` and `@edge-runtime/vm` to test Convex functions. Always install the latest versions of these packages. Configure vitest with `environment: "edge-runtime"` in `vitest.config.ts`.
 
 Test files go inside the `convex/` directory. You must pass a module map from `import.meta.glob` to `convexTest`:
+
 ```typescript
 /// <reference types="vite/client" />
 import { convexTest } from "convex-test";
@@ -293,13 +330,16 @@ test("some behavior", async () => {
   expect(messages).toMatchObject([{ body: "Hi!", author: "Sarah" }]);
 });
 ```
+
 The `modules` argument is required so convex-test can discover and load function files. The `/// <reference types="vite/client" />` directive is needed for TypeScript to recognize `import.meta.glob`.
 
 ## File storage guidelines
+
 - The `ctx.storage.getUrl()` method returns a signed URL for a given file. It returns `null` if the file doesn't exist.
 - Do NOT use the deprecated `ctx.storage.getMetadata` call for loading a file's metadata.
 
 Instead, query the `_storage` system table. For example, you can use `ctx.db.system.get` to get an `Id<"_storage">`.
+
 ```
 import { query } from "./_generated/server";
 import { Id } from "./_generated/dataModel";
@@ -321,6 +361,5 @@ export const exampleQuery = query({
     },
 });
 ```
+
 - Convex storage stores items as `Blob` objects. You must convert all items to/from a `Blob` when using Convex storage.
-
-

--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -46,6 +46,7 @@ const MAX_PROMPT_CONTEXT_CHARS = 90_000;
 const MAX_VERTEX_INLINE_FILE_BYTES = MAX_UPLOAD_FILE_BYTES;
 const MAX_VERTEX_INLINE_FILE_LABEL = MAX_UPLOAD_FILE_LABEL;
 const PRE_DOWNLOAD_CONTENT_LENGTH_TOLERANCE_BYTES = 128 * 1024;
+const LLM_GENERATION_TIMEOUT_MS = 60_000;
 const vertexProviderOptions = {
   google: {
     thinkingConfig: {
@@ -69,6 +70,7 @@ const vertexNativeFileExtensions = new Set<string>(
 const vertexNativeMediaTypes = new Set<string>(
   VERTEX_NATIVE_UPLOAD_MEDIA_TYPES,
 );
+const pdfMediaTypes = new Set(["application/pdf"]);
 
 const extensionToMediaType: Record<string, string> = {
   pdf: "application/pdf",
@@ -333,6 +335,14 @@ const isVertexNativeCandidate = (fileType: string, fileName: string) => {
   );
 };
 
+const isPdfDocument = (fileType: string, fileName: string) => {
+  const normalizedMediaType = fileType.toLowerCase().split(";")[0]?.trim();
+  return (
+    (normalizedMediaType ? pdfMediaTypes.has(normalizedMediaType) : false) ||
+    filenameExtension(fileName) === "pdf"
+  );
+};
+
 const resolveMediaType = (fileType: string, fileName: string) => {
   if (fileType && fileType !== "application/octet-stream") {
     return fileType;
@@ -458,6 +468,13 @@ const buildModelInputFromDocuments = async (
         fileSizeBytes: document.fileSizeBytes,
       });
 
+      if (document.extractedText) {
+        textOnlyDocuments.push({
+          fileName: document.fileName,
+          extractedText: document.extractedText,
+        });
+      }
+
       if (
         Number.isFinite(document.fileSizeBytes) &&
         (document.fileSizeBytes ?? 0) > MAX_VERTEX_INLINE_FILE_BYTES
@@ -553,6 +570,37 @@ const buildModelInputFromDocuments = async (
 
       const mediaType = resolveMediaType(document.fileType, document.fileName);
       const documentBuffer = Buffer.from(arrayBuffer);
+
+      if (
+        !document.extractedText &&
+        isPdfDocument(mediaType, document.fileName)
+      ) {
+        try {
+          const extractedText = await extractTextFromBytes(
+            document.fileName,
+            mediaType,
+            documentBuffer,
+          );
+
+          if (extractedText) {
+            textOnlyDocuments.push({
+              fileName: document.fileName,
+              extractedText,
+            });
+            trace?.log("info", "model_input_pdf_text_extracted", {
+              fileName: document.fileName,
+              extractedLength: extractedText.length,
+              elapsedMs: Date.now() - fileLoadStartedAt,
+            });
+          }
+        } catch (error) {
+          trace?.log("warn", "model_input_pdf_text_extraction_failed", {
+            fileName: document.fileName,
+            error: extractErrorForLog(error),
+            elapsedMs: Date.now() - fileLoadStartedAt,
+          });
+        }
+      }
 
       fileParts.push({
         type: "file",
@@ -2249,9 +2297,13 @@ export const extractDocumentContent = action({
     });
 
     // Hybrid approach:
-    // - Native Vertex file path for PDF/image formats supported by Gemini.
-    // - officeparser/text extraction fallback for Office/text formats.
-    if (isVertexNativeCandidate(document.fileType, document.fileName)) {
+    // - PDFs are attached natively and also text-extracted when possible.
+    // - Images stay native-only because there is no useful text extraction path.
+    // - Office/text formats use extracted text.
+    if (
+      isVertexNativeCandidate(document.fileType, document.fileName) &&
+      !isPdfDocument(document.fileType, document.fileName)
+    ) {
       trace.log("info", "skip_text_extraction_vertex_native", {
         fileName: document.fileName,
         fileType: document.fileType,
@@ -2327,6 +2379,27 @@ export const extractDocumentContent = action({
         error instanceof Error
           ? error.message
           : "Unbekannter Fehler bei der Extraktion.";
+
+      if (isPdfDocument(document.fileType, document.fileName)) {
+        trace.log("warn", "pdf_text_extraction_failed_using_native_file", {
+          documentId: args.documentId,
+          fileName: document.fileName,
+          error: extractErrorForLog(error),
+        });
+
+        await ctx.runMutation(internal.study.setDocumentExtractionResult, {
+          documentId: args.documentId,
+          extractionStatus: "ready",
+          extractionError:
+            "PDF-Text konnte nicht extrahiert werden. Die Datei wird direkt an die KI übergeben.",
+        });
+
+        return {
+          documentId: args.documentId,
+          extractionStatus: "ready" as const,
+          error: message,
+        };
+      }
 
       trace.log("error", "extraction_failed", {
         documentId: args.documentId,
@@ -2557,6 +2630,7 @@ Anforderungen:
           temperature: 0.1,
           maxOutputTokens: 3_000,
           thinkingBudget: 0,
+          timeoutMs: LLM_GENERATION_TIMEOUT_MS,
           sourceContextLength: sourceContext.length,
           filePartCount: fileParts.length,
         });
@@ -2567,6 +2641,7 @@ Anforderungen:
           model: model("gemini-3-flash-preview"),
           temperature: 0.1,
           maxOutputTokens: 3_000,
+          timeout: { totalMs: LLM_GENERATION_TIMEOUT_MS },
           providerOptions: vertexProviderOptions,
           output: Output.object({
             schema: quizGenerationSchema,
@@ -2633,6 +2708,7 @@ Anforderungen:
               temperature: 0.2,
               maxOutputTokens: 2_000,
               thinkingBudget: 0,
+              timeoutMs: LLM_GENERATION_TIMEOUT_MS,
               sourceContextLength: sourceContext.length,
             });
 
@@ -2642,6 +2718,7 @@ Anforderungen:
               model: model("gemini-3-flash-preview"),
               temperature: 0.1,
               maxOutputTokens: 3_000,
+              timeout: { totalMs: LLM_GENERATION_TIMEOUT_MS },
               providerOptions: vertexProviderOptions,
               output: Output.object({
                 schema: quizGenerationSchema,
@@ -2694,6 +2771,7 @@ Anforderungen:
               temperature: 0.1,
               maxOutputTokens: 3_000,
               thinkingBudget: 0,
+              timeoutMs: LLM_GENERATION_TIMEOUT_MS,
               sourceContextLength: 0,
             });
 
@@ -2703,6 +2781,7 @@ Anforderungen:
               model: model("gemini-3-flash-preview"),
               temperature: 0.1,
               maxOutputTokens: 3_000,
+              timeout: { totalMs: LLM_GENERATION_TIMEOUT_MS },
               providerOptions: vertexProviderOptions,
               output: Output.json(),
               experimental_telemetry: buildAiSdkTelemetry(
@@ -3172,6 +3251,7 @@ Liefere jetzt ausschließlich eine Antwort, die alle Mengenregeln exakt erfüllt
             temperature: 0.1,
             maxOutputTokens: 3_000,
             thinkingBudget: 0,
+            timeoutMs: LLM_GENERATION_TIMEOUT_MS,
             sourceContextLength: sourceContext.length,
             filePartCount: fileParts.length,
           });
@@ -3182,6 +3262,7 @@ Liefere jetzt ausschließlich eine Antwort, die alle Mengenregeln exakt erfüllt
             model: model("gemini-3-flash-preview"),
             temperature: 0.1,
             maxOutputTokens: 3_000,
+            timeout: { totalMs: LLM_GENERATION_TIMEOUT_MS },
             providerOptions: vertexProviderOptions,
             output: Output.object({
               schema: quizGenerationSchema,
@@ -3508,6 +3589,7 @@ Gib eine objektive Bewertung mit einem Score zwischen 0 und 100 wie gut die Antw
             temperature: 0.1,
             maxOutputTokens: 300,
             thinkingBudget: 0,
+            timeoutMs: LLM_GENERATION_TIMEOUT_MS,
             answeredWithDontKnow: args.answeredWithDontKnow,
             stage: attemptIndex === 0 ? "primary" : "retry",
           });
@@ -3518,6 +3600,7 @@ Gib eine objektive Bewertung mit einem Score zwischen 0 und 100 wie gut die Antw
             model: model("gemini-3-flash-preview"),
             temperature: 0.1,
             maxOutputTokens: 300,
+            timeout: { totalMs: LLM_GENERATION_TIMEOUT_MS },
             providerOptions: vertexProviderOptions,
             output: Output.object({
               schema: answerEvaluationSchema,
@@ -3596,6 +3679,7 @@ Gib eine objektive Bewertung mit einem Score zwischen 0 und 100 wie gut die Antw
             temperature: 0.1,
             maxOutputTokens: 400,
             thinkingBudget: 0,
+            timeoutMs: LLM_GENERATION_TIMEOUT_MS,
             answeredWithDontKnow: args.answeredWithDontKnow,
           });
 
@@ -3605,6 +3689,7 @@ Gib eine objektive Bewertung mit einem Score zwischen 0 und 100 wie gut die Antw
             model: model("gemini-3-flash-preview"),
             temperature: 0.1,
             maxOutputTokens: 400,
+            timeout: { totalMs: LLM_GENERATION_TIMEOUT_MS },
             providerOptions: vertexProviderOptions,
             output: Output.json(),
             experimental_telemetry: buildAiSdkTelemetry(
@@ -3963,6 +4048,7 @@ Pflichtregeln:
                 temperature: 0.2,
                 maxOutputTokens: 600,
                 thinkingBudget: 0,
+                timeoutMs: LLM_GENERATION_TIMEOUT_MS,
               });
 
               llmAttempts += 1;
@@ -3983,6 +4069,7 @@ Pflichtregeln:
                   model: model("gemini-3-flash-preview"),
                   temperature: 0.2,
                   maxOutputTokens: 600,
+                  timeout: { totalMs: LLM_GENERATION_TIMEOUT_MS },
                   providerOptions: vertexProviderOptions,
                   output: Output.object({
                     schema: focusTopicAnalysisOutputSchema,
@@ -4134,6 +4221,7 @@ Pflichtregeln:
               temperature: 0.2,
               maxOutputTokens: 1_500,
               thinkingBudget: 0,
+              timeoutMs: LLM_GENERATION_TIMEOUT_MS,
             });
 
             llmAttempts += 1;
@@ -4154,6 +4242,7 @@ Pflichtregeln:
                 model: model("gemini-3-flash-preview"),
                 temperature: 0.2,
                 maxOutputTokens: 1_500,
+                timeout: { totalMs: LLM_GENERATION_TIMEOUT_MS },
                 providerOptions: vertexProviderOptions,
                 output: Output.object({
                   schema: analysisOutputSchema,
@@ -4552,6 +4641,7 @@ Nutze das bereitgestellte Lernmaterial umfassend. Gehe auf Details, Zusammenhän
           temperature: 0.25,
           maxOutputTokens: 2_500,
           thinkingBudget: 0,
+          timeoutMs: LLM_GENERATION_TIMEOUT_MS,
           sourceContextLength: sourceContext.length,
           filePartCount: fileParts.length,
           avgScore,
@@ -4564,6 +4654,7 @@ Nutze das bereitgestellte Lernmaterial umfassend. Gehe auf Details, Zusammenhän
           model: model("gemini-3-flash-preview"),
           temperature: 0.25,
           maxOutputTokens: 2_500,
+          timeout: { totalMs: LLM_GENERATION_TIMEOUT_MS },
           providerOptions: vertexProviderOptions,
           output: Output.object({
             schema: deepDiveSchema,

--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -494,10 +494,6 @@ const buildModelInputFromDocuments = async (
         await createDocumentReadUrl(ctx, document, accessKey, trace);
       if (!fileUrl) {
         if (document.extractedText) {
-          textOnlyDocuments.push({
-            fileName: document.fileName,
-            extractedText: document.extractedText,
-          });
           continue;
         }
         throw new Error(
@@ -516,10 +512,6 @@ const buildModelInputFromDocuments = async (
       const response = await fetch(fileUrl);
       if (!response.ok) {
         if (document.extractedText) {
-          textOnlyDocuments.push({
-            fileName: document.fileName,
-            extractedText: document.extractedText,
-          });
           continue;
         }
         throw new Error(


### PR DESCRIPTION
## Summary
- PDFs are no longer native-only. The backend now tries to extract PDF text and includes that as sourceContext alongside the PDF file.
- Existing already-uploaded PDFs also get a generation-time text extraction attempt, so you should not have to re-upload just to test this.
- If PDF text extraction fails, the document still stays usable and falls back to the raw PDF attachment.
- All generateText(...) calls now have a 60s timeout, and the timeout value is logged before the LLM call. That should prevent future traces from disappearing right after llm_primary_request.
- Format code (`pnpm format`

## Testing
- Not run (not requested)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/smartnotes-germany/smartnotes-mvp/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF document support with automatic text extraction for AI processing.
  * Timeout protection for LLM generation requests.

* **Improvements**
  * More robust PDF handling with graceful fallback when extraction fails (PDFs are still processed by the AI).
  * Widespread documentation and example formatting updates across skill guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->